### PR TITLE
TEL-26690: Explicitly enable core dump capability on startup

### DIFF
--- a/calltable.cpp
+++ b/calltable.cpp
@@ -715,12 +715,6 @@ Call::Call(int call_type, char *call_id, unsigned long call_id_len, vector<strin
 	first_branch.call = this;
 	branch_main_id = 0;
 	_branches_lock = 0;
-
-  // TODO(kavin): delete after testing
-	if(call_type == INVITE) {
-		volatile char *crash_ptr = (volatile char *)0xdeadbeef;
-		crash_ptr[0] = 0x42;
-	}
   
 	//increaseTartimemap(time);
 	has_second_merged_leg = false;

--- a/calltable.cpp
+++ b/calltable.cpp
@@ -715,6 +715,12 @@ Call::Call(int call_type, char *call_id, unsigned long call_id_len, vector<strin
 	first_branch.call = this;
 	branch_main_id = 0;
 	_branches_lock = 0;
+
+  // TODO(kavin): delete after testing
+	if(call_type == INVITE) {
+		volatile char *crash_ptr = (volatile char *)0xdeadbeef;
+		crash_ptr[0] = 0x42;
+	}
   
 	//increaseTartimemap(time);
 	has_second_merged_leg = false;

--- a/voipmonitor.cpp
+++ b/voipmonitor.cpp
@@ -4808,7 +4808,7 @@ int main_init_read() {
 	rlp.rlim_max = RLIM_INFINITY;
 	if (setrlimit(RLIMIT_CORE, &rlp) < 0)
 		fprintf(stderr, "setrlimit: %s\nWarning: core dumps may be truncated or non-existant\n", strerror(errno));
-	// TEL-26690: Core dumps were disabled due to setcap limiting Voipmonitor's permissions.
+  // TEL-26690: Core dumps were disabled due to setcap limiting Voipmonitor's permissions.
   // We need to explictly enable them on startup now.
 	if (prctl(PR_SET_DUMPABLE, 1) < 0)
 		fprintf(stderr, "prctl(PR_SET_DUMPABLE): %s\nCore dumps may be disabled\n", strerror(errno));

--- a/voipmonitor.cpp
+++ b/voipmonitor.cpp
@@ -28,6 +28,7 @@
 #else
 #include <endian.h>
 #include <sys/inotify.h>
+#include <sys/prctl.h>
 #endif
 
 #include <arpa/inet.h>
@@ -4807,6 +4808,10 @@ int main_init_read() {
 	rlp.rlim_max = RLIM_INFINITY;
 	if (setrlimit(RLIMIT_CORE, &rlp) < 0)
 		fprintf(stderr, "setrlimit: %s\nWarning: core dumps may be truncated or non-existant\n", strerror(errno));
+	// TEL-26690: Core dumps were disabled due to setcap limiting Voipmonitor's permissions.
+  // We need to explictly enable them on startup now.
+	if (prctl(PR_SET_DUMPABLE, 1) < 0)
+		fprintf(stderr, "prctl(PR_SET_DUMPABLE): %s\nCore dumps may be disabled\n", strerror(errno));
 	
 	if(!opt_nocdr && !is_sender() && !is_client_packetbuffer_sender()) {
 		custom_headers_cdr = new FILE_LINE(42014) CustomHeaders(CustomHeaders::cdr, sqlDbInit);


### PR DESCRIPTION
Summary: Coredumps were disabled due to a recent change introducing `setcap` which removes Voipmonitors permission to create them. (There is no setcap value to enable coredumps). 

Enabling `PR_SET_DUMPABLE` on voipmon startup fixes this without having to enable it for the entire machine. (`echo 1 > /proc/sys/fs/suid_dumpable` enables it globally)

Ticket: https://dialpad.atlassian.net/browse/TEL-26690

Tests done: Tested on k8 & BM by intentionally adding an out of bounds write on SIP INVITE. Then I veriffied a coredump is created & `bt` correctly executes on it. 